### PR TITLE
Update and pin GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,10 @@ jobs:
     container:
       image: ruby:3.3.6
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/configure-pages@v3
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
       - name: Install dependencies
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         run: |
           bundle exec middleman build
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: build/
 
@@ -46,4 +46,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,10 @@ jobs:
     container:
       image: ruby:3.3.6
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
       - name: Install dependencies
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         run: |
           bundle exec middleman build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: build/
 
@@ -46,4 +46,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Summary

- Update all GitHub Actions to latest versions
- Pin each action to a commit hash for security

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v3 | v4.3.1 |
| actions/configure-pages | v3 | v5.0.0 |
| actions/setup-node | v2 | v4.4.0 |
| actions/upload-pages-artifact | v1 | v3.0.1 |
| actions/deploy-pages | v1 | v4.0.5 |

## Test plan

- [ ] Confirm the Build workflow passes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)